### PR TITLE
Clone default http.Transport before using!

### DIFF
--- a/client.go
+++ b/client.go
@@ -43,7 +43,11 @@ var HTTPClientCtxKey struct{}
 //     context.WithValue(ctx, oidc.HTTPClientCtxKey, client)
 //
 func doRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
-	client := http.DefaultClient
+	// Clone transport before. We don't want to depend on default one.
+	clonedTransport := &(*http.DefaultTransport.(*http.Transport))
+	client := &http.Client{
+		Transport: clonedTransport,
+	}
 	if c, ok := ctx.Value(HTTPClientCtxKey).(*http.Client); ok {
 		client = c
 	}

--- a/client.go
+++ b/client.go
@@ -43,7 +43,7 @@ var HTTPClientCtxKey struct{}
 //     context.WithValue(ctx, oidc.HTTPClientCtxKey, client)
 //
 func doRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
-	// Clone transport before. We don't want to depend on default one.
+	// Clone transport before using it. We don't want to depend on the default one.
 	clonedTransport := &(*http.DefaultTransport.(*http.Transport))
 	client := &http.Client{
 		Transport: clonedTransport,


### PR DESCRIPTION
- otherwise it leads to weird bugs with "leaking" rootCA or other http options ^^

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>